### PR TITLE
Add support for checking more than 1 build

### DIFF
--- a/tasks/lib/buildFinder.js
+++ b/tasks/lib/buildFinder.js
@@ -14,24 +14,25 @@ BuildFinder = function (builds) {
 };
 
 /**
- * Finds a build by the vcs revision
+ * Finds builds by the vcs revision
  *
  * @param {String} commit The commit hash
- * @returns {Build|null}
+ * @returns {Array|null}
  */
-BuildFinder.prototype.findByCommit = function (commit) {
-    var activeBuilds = this.builds.filter(function (build) {
-        return commit === build.vcs_revision;
-    });
+ BuildFinder.prototype.findByCommit = function (commit) {
+     var activeBuilds = this.builds.filter(function (build) {
+         return commit === build.vcs_revision;
+     });
 
-    // Check if there are matching builds
-    if (!activeBuilds.length) {
-        return null;
-    }
+     // Check if there are matching builds
+     if (!activeBuilds.length) {
+         return null;
+     }
 
-    // get the first matching build
-    return new Build(activeBuilds.shift());
-};
+     return activeBuilds.map(function (activeBuild) {
+         return new Build(activeBuild);
+     });
+ };
 
 
 module.exports = BuildFinder;

--- a/test/buildFinder.test.js
+++ b/test/buildFinder.test.js
@@ -12,7 +12,8 @@ module.exports = {
     },
 
     'finds by commit': function (test) {
-        test.strictEqual(finder.findByCommit('hashofthecommit') instanceof Build, true, 'should return an instance of Build');
+        var result = finder.findByCommit('hashofthecommit');
+        test.strictEqual(result[0] instanceof Build, true, 'should return an instance of Build');
         test.done();
     },
 


### PR DESCRIPTION
Before, it was looking for the first coincident build and, if found one, checking the status (success or failure). Now, with Circle CI 2, there can be up to n builds, where n is the amount of workflows.

This PR adds support to check all the coincident builds.